### PR TITLE
Various updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -321,7 +321,7 @@ locals {
         }
       }
 
-      environment = local.ecs_environment
+      environment = flatten([local.ecs_environment, var.environment])
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,10 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "hasura" {
   cidr_block = "172.17.0.0/16"
+
+  tags = {
+    Name = "hasura"
+  }
 }
 
 # Create var.az_count private subnets for RDS, each in a different AZ
@@ -59,6 +63,10 @@ resource "aws_subnet" "hasura_rds" {
   cidr_block        = cidrsubnet(aws_vpc.hasura.cidr_block, 8, count.index)
   availability_zone = data.aws_availability_zones.available.names[count.index]
   vpc_id            = aws_vpc.hasura.id
+
+  tags = {
+    Name = "hasura #${count.index} (private)"
+  }
 }
 
 # Create var.az_count public subnets for Hasura, each in a different AZ
@@ -68,11 +76,19 @@ resource "aws_subnet" "hasura_ecs" {
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   vpc_id                  = aws_vpc.hasura.id
   map_public_ip_on_launch = true
+
+  tags = {
+    Name = "hasura #${var.az_count + count.index} (public)"
+  }
 }
 
 # IGW for the public subnet
 resource "aws_internet_gateway" "hasura" {
   vpc_id = aws_vpc.hasura.id
+
+  tags = {
+    Name = "hasura"
+  }
 }
 
 # Route the public subnet traffic through the IGW

--- a/main.tf
+++ b/main.tf
@@ -457,3 +457,18 @@ resource "aws_route53_record" "hasura" {
   }
 }
 
+output "vpc" {
+  value = aws_vpc.hasura
+}
+
+output "private_subnets" {
+  value = aws_subnet.hasura_rds
+}
+
+output "public_subnets" {
+  value = aws_subnet.hasura_ecs
+}
+
+output "ecs_security_group" {
+  value = aws_security_group.hasura_ecs
+}

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ data "aws_availability_zones" "available" {
 }
 
 resource "aws_vpc" "hasura" {
-  cidr_block = "172.17.0.0/16"
+  cidr_block           = "172.17.0.0/16"
   enable_dns_hostnames = var.vpc_enable_dns_hostnames
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ data "aws_availability_zones" "available" {
 
 resource "aws_vpc" "hasura" {
   cidr_block = "172.17.0.0/16"
+  enable_dns_hostnames = var.vpc_enable_dns_hostnames
 
   tags = {
     Name = "hasura"

--- a/vars.tf
+++ b/vars.tf
@@ -66,3 +66,8 @@ variable "multi_az" {
   description = "Whether to deploy RDS and ECS in multi AZ mode or not"
   default     = true
 }
+
+variable "vpc_enable_dns_hostnames" {
+  description = "A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false."
+  default     = false
+}

--- a/vars.tf
+++ b/vars.tf
@@ -71,3 +71,8 @@ variable "vpc_enable_dns_hostnames" {
   description = "A boolean flag to enable/disable DNS hostnames in the VPC. Defaults false."
   default     = false
 }
+
+variable "environment" {
+  description = "Environment variables for ECS task: [ { name = \"foo\", value = \"bar\" }, ..]"
+  default     = []
+}


### PR DESCRIPTION
Hi @Rayraegah, sorry for lumping these all in to one PR.

We've been iterating quickly and fell behind pushing these back up, we'll try and be better going forward!

There's nothing major in here, just:
1. Adding some [tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) so it's easier to identify resources in the AWS console
1. Adding some outputs for the network resources (we needed these to set up a security group for a VPC endpoint we use to secure our lambda).
1. Renaming the subnets to align with [the convention AWS uses](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Scenario2.html).
1. Allow env vars to be set on the ECS task (useful for [setting event trigger webhook URLs via an env var](https://docs.hasura.io/1.0/graphql/manual/event-triggers/create-trigger.html#parameters))
1. Finally we used [`fmt`](https://www.terraform.io/docs/commands/fmt.html) to clean everything up.

Additionally, as an FYI, we're now exclusively targeting 0.12, which [was released 9 days ago](https://www.hashicorp.com/blog/announcing-terraform-0-12). All our PRs will this be targeting the `terraform-0.12` branch.