### PR TITLE
Prevent destruction of aws_db_instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -203,6 +203,10 @@ resource "aws_db_instance" "hasura" {
   backup_retention_period     = 7
   backup_window               = "04:00-06:00"
   final_snapshot_identifier   = "hasura"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Uses lifecycle method to prevent Terraform from accidentally deleting the database.

This post does a nice job of summarizing the problem as well as the solution.
https://coderbook.com/@marcus/prevent-terraform-from-recreating-or-deleting-resource/

Here's a link to the documentation as well: https://www.terraform.io/docs/configuration/resources.html#prevent_destroy