### PR TITLE
Use /healthz endpoint for ALB health check

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -431,8 +431,8 @@ resource "aws_alb_target_group" "hasura" {
   target_type = "ip"
 
   health_check {
-    path    = "/"
-    matcher = "302"
+    path    = "/healthz"
+    matcher = "200"
   }
 }
 


### PR DESCRIPTION
Allows ECS to see task is up when `hasura_console_enabled` is `false`.

https://docs.hasura.io/1.0/graphql/manual/api-reference/index.html#health-check-api