### PR TITLE
Graphql Subdomain Customization 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@
 
 resource "aws_iam_service_linked_role" "ecs_service" {
   aws_service_name = "ecs.amazonaws.com"
+  count            = var.create_iam_service_linked_role ? 1 : 0
 }
 
 # -----------------------------------------------------------------------------
@@ -11,7 +12,7 @@ resource "aws_iam_service_linked_role" "ecs_service" {
 # -----------------------------------------------------------------------------
 
 resource "aws_acm_certificate" "hasura" {
-  domain_name       = "hasura.${var.domain}"
+  domain_name       = "${var.hasura_subdomain}.${var.domain}"
   validation_method = "DNS"
 
   lifecycle {
@@ -375,8 +376,9 @@ resource "aws_ecs_service" "hasura" {
 # -----------------------------------------------------------------------------
 
 resource "aws_s3_bucket" "hasura" {
-  bucket = "hasura-${var.region}-${var.domain}"
-  acl    = "private"
+  bucket        = "hasura-${var.region}-${var.hasura_subdomain}-${var.domain}"
+  acl           = "private"
+  force_destroy = "true"
 }
 
 # -----------------------------------------------------------------------------
@@ -458,7 +460,7 @@ resource "aws_alb_listener" "hasura" {
 
 resource "aws_route53_record" "hasura" {
   zone_id = data.aws_route53_zone.hasura.zone_id
-  name    = "hasura.${var.domain}"
+  name    = "${var.hasura_subdomain}.${var.domain}"
   type    = "A"
 
   alias {

--- a/variables.tf
+++ b/variables.tf
@@ -16,16 +16,21 @@ variable "region" {
 }
 
 variable "domain" {
-  description = "Domain name. Service will be deployed at hasura.domain"
+  description = "Domain name. Service will be deployed using the hasura_subdomain"
+}
+
+variable "hasura_subdomain" {
+  description = "The Subdomain for your hasura graphql service."
+  default     = "hasura"
 }
 
 variable "app_subdomain" {
-  description = "The Subdomain for your application that will make CORS requests to hasura.domain"
+  description = "The Subdomain for your application that will make CORS requests to the hasura_subdomain"
   default     = "app"
 }
 variable "hasura_version_tag" {
   description = "The hasura graphql engine version tag"
-  default     = "v1.0.0-beta.3"
+  default     = "v1.0.0"
 }
 
 variable "hasura_admin_secret" {
@@ -84,5 +89,10 @@ variable "environment" {
 
 variable "additional_db_security_groups" {
   description = "List of Security Group IDs to have access to the RDS instance"
-  default = []
+  default     = []
+}
+
+variable "create_iam_service_linked_role" {
+  description = "Whether to create IAM service linked role for AWS ElasticSearch service. Can be only one per AWS account."
+  default     = true
 }


### PR DESCRIPTION
This adds an additional variable to allow for the customization of the subdomain which the hasura service is deployed to. 

I also included a flag to close #17 by utilizing the count parameter based on a newly defined `create_iam_service_linked_role` variable.

I apologize if this has too many items in for a single PR. I just started making a couple changes to our fork and didn't think to better handle it for a separate PR for each. I hope thats ok.
