### PR TITLE
Parameterize cluster name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ resource "aws_db_instance" "hasura" {
 # -----------------------------------------------------------------------------
 
 resource "aws_ecs_cluster" "hasura" {
-  name = "hasura-cluster"
+  name = ${var.ecs_cluster_name}
 }
 
 # -----------------------------------------------------------------------------

--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ resource "aws_db_instance" "hasura" {
 # -----------------------------------------------------------------------------
 
 resource "aws_ecs_cluster" "hasura" {
-  name = ${var.ecs_cluster_name}
+  name = "${var.ecs_cluster_name}"
 }
 
 # -----------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,8 @@ variable "create_iam_service_linked_role" {
   description = "Whether to create IAM service linked role for AWS ElasticSearch service. Can be only one per AWS account."
   default     = true
 }
+
+variable "ecs_cluster_name" {
+  description = "The name to assign to the ECS cluster"
+  default     = "hasura-cluster"
+}


### PR DESCRIPTION
This will allow you to control the ECS cluster name which is useful if you want to have multiple hasura clusters in the same region (prod, dev, etc).

For example:
```
  ecs_cluster_name         = "hasura-${var.env}-cluster"
```