### PR TITLE
Change variable to avoid interpolation-only expression

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,7 +215,7 @@ resource "aws_db_instance" "hasura" {
 # -----------------------------------------------------------------------------
 
 resource "aws_ecs_cluster" "hasura" {
-  name = "${var.ecs_cluster_name}"
+  name = var.ecs_cluster_name
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Interpolations-only expressions are generating a warning in Terraform v0.13.2.