### PR TITLE
Fix Indices Support in Domain Validation Options

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,10 +30,10 @@ data "aws_route53_zone" "hasura" {
 
 resource "aws_route53_record" "hasura_validation" {
   depends_on = [aws_acm_certificate.hasura]
-  name       = aws_acm_certificate.hasura.domain_validation_options[0]["resource_record_name"]
-  type       = aws_acm_certificate.hasura.domain_validation_options[0]["resource_record_type"]
+  name       = toList(aws_acm_certificate.hasura.domain_validation_options)[0]["resource_record_name"]
+  type       = toList(aws_acm_certificate.hasura.domain_validation_options)[0]["resource_record_type"]
   zone_id    = data.aws_route53_zone.hasura.zone_id
-  records    = [aws_acm_certificate.hasura.domain_validation_options[0]["resource_record_value"]]
+  records    = [toList(aws_acm_certificate.hasura.domain_validation_options)[0]["resource_record_value"]]
   ttl        = 300
 }
 


### PR DESCRIPTION
I Just changes aws_acm_certificate.hasura.domain_validation_options[0]
to be -->
toList(aws_acm_certificate.hasura.domain_validation_options)[0]
so the module can work .