### PR TITLE
Enable control over HASURA_GRAPHQL_CORS_DOMAIN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -292,7 +292,7 @@ locals {
     },
     {
       name  = "HASURA_GRAPHQL_CORS_DOMAIN",
-      value = "https://${var.app_subdomain}.${var.domain}:443, https://${var.app_subdomain}.${var.domain}"
+      value = "${var.hasura_graphql_cors_domain == "" ? "https://${var.app_subdomain}.${var.domain}:443, https://${var.app_subdomain}.${var.domain}" : var.hasura_graphql_cors_domain}"
     },
     {
       name  = "HASURA_GRAPHQL_PG_CONNECTIONS",

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,11 @@ variable "hasura_console_enabled" {
   default     = "true"
 }
 
+variable "hasura_graphql_cors_domain" {
+  description = "comma seperated list of domains to enable cors on. Also accepts * which will enable cors from all sub domain and domains. By default if not used it will use this module's app_subdomain and domain variables"
+  default     = ""
+}
+
 variable "rds_username" {
   description = "The username for RDS"
 }


### PR DESCRIPTION
This PR enables control over the env variable HASURA_GRAPHQL_CORS_DOMAIN

If this env is not used, it will default to the standard settings in this module.

I need this because I want to setup migrations via Hasura console as documented [here](https://hasura.io/docs/1.0/graphql/core/migrations/migrations-setup.html#step-0-disable-the-console-on-the-server) yet I cannot get to the local console to modify the database schema due to cors as described [here.](https://github.com/hasura/graphql-engine/issues/4735) Upon checking, there's no way for me to access this via localhost without this modification
