### PR TITLE
Update deprecated field name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,7 @@ resource "aws_db_subnet_group" "hasura" {
 }
 
 resource "aws_db_instance" "hasura" {
-  name                   = var.rds_db_name
+  db_name                = var.rds_db_name
   identifier             = "hasura"
   username               = var.rds_username
   password               = var.rds_password


### PR DESCRIPTION
```
╷
│ Warning: Argument is deprecated
│
│   with module.hasura.aws_db_instance.hasura,
│   on .terraform/modules/hasura/main.tf line 180, in resource "aws_db_instance" "hasura":
│  180:   name                   = var.rds_db_name
│
│ Use db_name instead
│
│ (and 2 more similar warnings elsewhere)
```